### PR TITLE
Fix README license heading and site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-# [www.bicrement.com](http://www.bicrement.com)
+# [www.bicrement.com](https://www.bicrement.com)
 
-## LICENCES
+## Licenses
 
 [Attribution-NonCommercial-ShareAlike 3.0 Unported](http://creativecommons.org/licenses/by-nc-sa/3.0/).
+
+To run the site locally:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```

--- a/_mdwriter.cson
+++ b/_mdwriter.cson
@@ -21,11 +21,11 @@ sitePostsDir: "_posts/{year}/"
 # directory to images from the root of siteLocalDir
 siteImagesDir: "images/{year}/{month}/"
 # URL to your blog
-siteUrl: "http://www.bicrement.com/"
+siteUrl: "https://www.bicrement.com/"
 # URLs to tags/posts/categories JSON file
-urlForTags: "http://www.bicrement.com/blog/tags.json"
-urlForPosts: "http://www.bicrement.com/blog/posts.json"
-urlForCategories: "http://www.bicrement.com/blog/categories.json"
+urlForTags: "https://www.bicrement.com/blog/tags.json"
+urlForPosts: "https://www.bicrement.com/blog/posts.json"
+urlForCategories: "https://www.bicrement.com/blog/categories.json"
 # front matter template
 frontMatter: """
 ---

--- a/_posts/2013/2013-08-22-jekyll-snippets.markdown
+++ b/_posts/2013/2013-08-22-jekyll-snippets.markdown
@@ -8,7 +8,7 @@ tags: Jekyll Liquid Github Tip
 categories: Blog
 ---
 
-After a few hours work, a static [bicrement](http://www.bicrement.com) site is up now :D.
+After a few hours work, a static [bicrement](https://www.bicrement.com) site is up now :D.
 
 These are some tips and snippets on Jekyll, which I spent some time figured out in the process.
 
@@ -33,7 +33,7 @@ You can use `page.next` and `page.previous` to access the previous and next post
 ## Display year/month in archive page
 
 If you want to display `year` and `month` in archive page like
-[my blog page](http://www.bicrement.com/blog/), here is the code:
+[my blog page](https://www.bicrement.com/blog/), here is the code:
 
 {% highlight html %}
 {% raw %}

--- a/_posts/2014/2014-08-27-rails-4-setup.markdown
+++ b/_posts/2014/2014-08-27-rails-4-setup.markdown
@@ -28,7 +28,7 @@ Edit `config/database.yml` to make sure DB setup is correct.
 
 ## Setup RSpec and Capybara
 
-Follow [RSpec Setup in Rails 4](http://www.bicrement.com/articles/2014/rspec-setup-in-rails-4.html).
+Follow [RSpec Setup in Rails 4](https://www.bicrement.com/articles/2014/rspec-setup-in-rails-4.html).
 
 ## Setup Bootstrap
 

--- a/_projects/2012-10-23-nus-ivle-sdk.markdown
+++ b/_projects/2012-10-23-nus-ivle-sdk.markdown
@@ -9,7 +9,7 @@ good: 2
 description: 'A JavaScript SDK for NUS ivle Learning Environment.'
 tools: ['JavaScript', 'ajax', 'api']
 source: 'https://github.com/zhuochun/nus-ivle-api'
-site: 'http://www.bicrement.com/nus-ivle-api/'
+site: 'https://www.bicrement.com/nus-ivle-api/'
 github: 'zhuochun/nus-ivle-api'
 tags: JavaScript AJAX SDK IVLE NUS
 category: Project
@@ -19,5 +19,5 @@ permalink: /project/nus-ivle-sdk.html
 A JavaScript SDK for [ivle](https://ivle.nus.edu.sg/) Learning Environment of
 National University of Singapore.
 
-Visit the SDK [demo page](http://www.bicrement.com/nus-ivle-api/).
+Visit the SDK [demo page](https://www.bicrement.com/nus-ivle-api/).
 ([LAPI](https://ivle.nus.edu.sg/LAPI/default.aspx) key is required.)


### PR DESCRIPTION
## Summary
- update site URL to HTTPS
- fix heading to **Licenses**
- add local setup instructions for Jekyll
- make links use HTTPS across config and posts

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6843a2cfc54c8326830ee7c6e155e18e