### PR TITLE
Add Newsletter section to home page with Substack posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,16 @@ script:
   </section>
 </div>
 
+<div class="posts newsletter-posts">
+  <h3 class="content-subhead">
+    Newsletter <a href="{{ site.social.substack }}" title="Bicrement Newsletter">FULL &raquo;</a>
+  </h3>
+
+  <div id="newsletter-posts">
+    <p class="post-meta newsletter-loading">Loading latest newsletter posts...</p>
+  </div>
+</div>
+
 <div class="posts">
   <h3 class="content-subhead">
     Recent Posts <a href="{{ site.page.blog }}" title="Bicrement Blog">MORE &raquo;</a>

--- a/js/home.js
+++ b/js/home.js
@@ -13,4 +13,65 @@ $(function() {
     $(".greeting").html(sayaword());
 
     $(".sidebar").addClass("sidebar-color-" + date.getDay());
+
+    function formatNewsletterDate(value) {
+        if (!value) {
+            return "";
+        }
+
+        var parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return "";
+        }
+
+        return parsed.toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            year: "numeric"
+        });
+    }
+
+    function buildNewsletterItem(item) {
+        var title = item.title || "Untitled";
+        var link = item.canonical_url || item.url || (item.slug ? "https://bicrement.substack.com/p/" + item.slug : "https://bicrement.substack.com/");
+        var dateText = formatNewsletterDate(item.post_date || item.published_at || item.created_at);
+
+        var metaText = dateText ? "On " + dateText + " about newsletter" : "Newsletter";
+
+        return (
+            "<section class=\"post\">" +
+                "<header class=\"post-header\">" +
+                    "<h2 class=\"post-title\">" +
+                        "<a href=\"" + link + "\" title=\"" + title + "\">" + title + "</a>" +
+                    "</h2>" +
+                    "<p class=\"post-meta\">" + metaText + "</p>" +
+                "</header>" +
+            "</section>"
+        );
+    }
+
+    function loadNewsletterPosts() {
+        var container = $("#newsletter-posts");
+        if (!container.length) {
+            return;
+        }
+
+        fetch("https://bicrement.substack.com/api/v1/archive?limit=3")
+            .then(function(response) {
+                if (!response.ok) {
+                    throw new Error("Failed to load newsletter posts");
+                }
+                return response.json();
+            })
+            .then(function(data) {
+                var posts = Array.isArray(data) ? data : (data && data.posts ? data.posts : []);
+                var html = posts.slice(0, 3).map(buildNewsletterItem).join("");
+                container.html(html || "<p class=\"post-meta\">No newsletter posts available yet.</p>");
+            })
+            .catch(function() {
+                container.html("<p class=\"post-meta\">Unable to load newsletter posts right now.</p>");
+            });
+    }
+
+    loadNewsletterPosts();
 });


### PR DESCRIPTION
### Motivation
- Surface recent newsletter content from the site's Substack (`https://bicrement.substack.com/`) above the existing "Recent Posts" section so visitors can quickly access latest newsletter items. 
- Keep the newsletter entries styled like existing posts and have the "FULL »" link open the Substack site.

### Description
- Inserted a new `div.posts.newsletter-posts` block in `index.html` containing a `#newsletter-posts` container and a `Newsletter FULL »` link to `{{ site.social.substack }}`. 
- Added client-side logic in `js/home.js` to fetch the latest items from Substack's archive API (`/api/v1/archive?limit=3`) and render them using the same post markup via new functions `formatNewsletterDate`, `buildNewsletterItem`, and `loadNewsletterPosts`.
- Implemented graceful fallbacks and error messaging for loading failures and for missing post fields, and ensured links point to canonical URLs when available.

### Testing
- Attempted to build the site with `bundle exec jekyll build`, which failed due to the Ruby environment missing the `csv` stdlib (Jekyll process error), so the static build could not be validated. 
- Attempted to fetch the Substack API directly during development, which failed with a network/Tunnel error (`403 Forbidden`), so remote API retrieval could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e70948888326bd177fd71cd3e8bc)