### PR TITLE
Fix newsletter CORS fetch via AllOrigins proxy

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -56,7 +56,10 @@ $(function() {
             return;
         }
 
-        fetch("https://bicrement.substack.com/api/v1/archive?limit=3")
+        var newsletterUrl = "https://bicrement.substack.com/api/v1/archive?limit=3";
+        var proxyUrl = "https://api.allorigins.win/raw?url=" + encodeURIComponent(newsletterUrl);
+
+        fetch(proxyUrl)
             .then(function(response) {
                 if (!response.ok) {
                     throw new Error("Failed to load newsletter posts");


### PR DESCRIPTION
### Motivation
- The browser blocked direct requests to `https://bicrement.substack.com/api/v1/archive?limit=3` due to missing CORS headers, preventing newsletter posts from loading.

### Description
- Update `js/home.js` to construct a `newsletterUrl` and route the request through the AllOrigins proxy (`https://api.allorigins.win/raw?url=`) by replacing the direct `fetch` call with `fetch(proxyUrl)` so the archive can be retrieved client-side.

### Testing
- No automated tests were run for this static-site JavaScript change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e8e8e1008326bd821aae225f2f83)